### PR TITLE
Fixed issue Regex for DecimalIntLiteral #1

### DIFF
--- a/rocsho.par
+++ b/rocsho.par
@@ -10,7 +10,7 @@ Rocsho
     ;
 
 DecimalIntLiteral
-    : /[1-9][0-9]*/
+    : /0|[1-9][0-9]*/
     ;
 
 Expr
@@ -31,9 +31,8 @@ ParenExpr
     : '('^ Expr ')'^
     ;
 
-MulDivExpr // U+002f - slash (/)
-// FIXME: after upgrading regex-syntax to 0.7, replace \x2f with \/ 
-    : MulDivOperand { /\*|\x2f/ MulDivOperand }
+MulDivExpr
+    : MulDivOperand { "\*|/" MulDivOperand }
     ;
 
 MulDivOperand


### PR DESCRIPTION
Also use double quoted representation to avoid clash with slash